### PR TITLE
add Cloudforms.managers to packages to deliver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='http://github.com/01000101',
     author='Joshua Cornutt',
     author_email='jcornutt@gmail.com',
-    packages=['Cloudforms'],
+    packages=['Cloudforms', 'Cloudforms.managers'],
     classifiers=[
         'Intended Audience :: Developers',
         'Natural Language :: English',


### PR DESCRIPTION
Please let me know what kind of test I can do. I did the following:
```
prompt> virtualenv test && cd test && . ./bin/activate
(test) prompt> pip install https://github.com/mbee/python-cloudforms/archive/master.zip
(test) prompt> python -c "import Cloudforms" && echo "test OK"
test OK
(test) prompt>
```
That does not work on your repository, you will get the following error:
```
ImportError: No module named managers.provider
```